### PR TITLE
友情链接更新

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -15,7 +15,7 @@ mclink:
 Technologyfriendlnk:
   Tea9的博客: 'https//tea9.github.io'
   GloomyGhost的博客: 'https://gloomyghost.com'
-  童年是个风筝的博客: 'https://zhangqirun.cn'
+  童年是个风筝的博客: 'https://www.zhangqirun.cn/'
   文科中的技术宅: 'https://townwang.com'
   一之笔: 'https://yizibi.github.io'
 


### PR DESCRIPTION
请注意，目前zhangqirun.cn 绑定了邮件服务器，因此它将只能够用于邮件的发送和接收。
使用任何协议的链接访问zhangqirun.cn 将不再起作用，它将会显示为“找不到服务器的IP地址”。因此请务必更新。
另外，@tea9 的链接有误。应该为“https://tea9.github.io/ ”